### PR TITLE
Remove non-ASCII character for R 3.4.4 compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Type: Package
 Title: Bayesian Logistic Regression with Polya-Gamma latent variables
 Version: 0.1
 Date: 2015-10-19
-Author: Kaspar Märtens and Sherman Ip
-Maintainer: Kaspar Märtens <kaspar.martens@gmail.com>
+Author: Kaspar Martens and Sherman Ip
+Maintainer: Kaspar Martens <kaspar.martens@gmail.com>
 Description: Obtain an MCMC sample from the posterior distribution of parameter beta. To achieve this via Gibbs sampling, latent variables from the Polya-Gamma distribution are introduced.
 License: What license is it under?
 LazyData: TRUE


### PR DESCRIPTION
The current version causes a problem in R 3.4.4:

```
Downloading GitHub repo kasparmartens/PolyaGamma@master
✔  checking for file ‘/tmp/Rtmp2GCoOI/remotes3c5a582e9d3a/kasparmartens-PolyaGamma-c736ed1/DESCRIPTION’ (465ms)
─  preparing ‘PolyaGamma’:
✔  checking DESCRIPTION meta-information
   Warning in .write_description(db, ldpath) :
     Unknown encoding with non-ASCII data: converting to ASCII
   Error in iconv(x[ind], "latin1", "ASCII", sub = "byte") : 
     object 'ind' not found
   Execution halted
```

This is a [known issue](https://github.com/r-lib/devtools/issues/1734), fixed in R 3.5. For compatibility with R 3.4.4, I removed the non-ASCII character in my fork.